### PR TITLE
Fix: MCP server configuration for Claude Code

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,14 +3,7 @@
     "playwright": {
       "command": "npx",
       "args": [
-        "@playwright/mcp@latest",
-        "--browser",
-        "chromium",
-        "--session-dir",
-        "./playwright-sessions",
-        "--profile-dir",
-        "./browser-profiles",
-        "--auto-load-session"
+        "@playwright/mcp"
       ],
       "env": {
         "PLAYWRIGHT_AUTO_LOAD_SESSION": "true",

--- a/README.md
+++ b/README.md
@@ -457,10 +457,7 @@ The toolkit automatically configures Claude Code's MCP integration:
     "playwright": {
       "command": "npx",
       "args": [
-        "@playwright/mcp@latest",
-        "--browser=chromium", 
-        "--headless=false",
-        "--user-data-dir=./browser-profiles/default"
+        "@playwright/mcp"
       ]
     }
   }

--- a/docs/api.md
+++ b/docs/api.md
@@ -1215,10 +1215,7 @@ The toolkit automatically configures MCP in `~/.claude/claude_desktop_config.jso
     "playwright": {
       "command": "npx",
       "args": [
-        "@playwright/mcp@latest",
-        "--browser=chromium",
-        "--headless=false",
-        "--user-data-dir=./browser-profiles/default"
+        "@playwright/mcp"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-playwright",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Seamless integration between Claude Code and Playwright MCP for efficient browser automation and testing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/generators/init.ts
+++ b/src/generators/init.ts
@@ -225,10 +225,7 @@ async function generateMCPConfig(projectPath: string) {
       playwright: {
         command: 'npx',
         args: [
-          '@playwright/mcp@latest',
-          '--browser=chromium',
-          '--headless=false',
-          '--user-data-dir=./browser-profiles/default'
+          '@playwright/mcp'
         ]
       }
     }

--- a/src/generators/mcp-setup.ts
+++ b/src/generators/mcp-setup.ts
@@ -14,14 +14,7 @@ export async function setupMCPForClaude(projectPath: string): Promise<boolean> {
         playwright: {
           command: 'npx',
           args: [
-            '@playwright/mcp@latest',
-            '--browser',
-            'chromium',
-            '--session-dir',
-            './playwright-sessions',
-            '--profile-dir',
-            './browser-profiles',
-            '--auto-load-session'
+            '@playwright/mcp'
           ],
           env: {
             PLAYWRIGHT_AUTO_LOAD_SESSION: 'true',


### PR DESCRIPTION
## Summary
- Fixed incorrect MCP server configuration that was causing startup failures
- Removed invalid command-line arguments from @playwright/mcp invocation
- Updated all references in code, documentation, and config files

## Problem
The MCP server was failing to start in Claude Code because we were passing incorrect arguments to `@playwright/mcp`. The package doesn't accept the command-line arguments we were trying to pass.

## Solution
Simplified the configuration to just use `@playwright/mcp` without any additional arguments, as per the package's actual requirements.

## Test Plan
- [x] Built the project successfully
- [x] Tested configuration in actual Claude Code project
- [x] Verified MCP server starts correctly
- [x] Updated version to alpha.9

## Files Changed
- `.mcp.json` - Fixed MCP configuration
- `src/generators/mcp-setup.ts` - Updated generator
- `src/generators/init.ts` - Updated init command
- `README.md` - Updated documentation
- `docs/api.md` - Updated API docs
- `package.json` - Version bump to alpha.9