### PR TITLE
feat: Add URL validation for base URL configuration

### DIFF
--- a/scripts/mcp-interceptor.js
+++ b/scripts/mcp-interceptor.js
@@ -29,7 +29,22 @@ let projectConfig = {
 if (fs.existsSync(projectConfigPath)) {
   try {
     projectConfig = require(projectConfigPath);
-    console.error(`[MCP Interceptor] Base URL configured: ${projectConfig.baseURL}`);
+    
+    // Validate and fix baseURL if needed
+    if (projectConfig.baseURL && !projectConfig.baseURL.startsWith('http://') && !projectConfig.baseURL.startsWith('https://')) {
+      console.error(`[MCP Interceptor] WARNING: Base URL missing protocol, adding http://`);
+      projectConfig.baseURL = `http://${projectConfig.baseURL}`;
+    }
+    
+    // Validate URL format
+    try {
+      new URL(projectConfig.baseURL);
+      console.error(`[MCP Interceptor] Base URL configured: ${projectConfig.baseURL}`);
+    } catch (urlErr) {
+      console.error(`[MCP Interceptor] ERROR: Invalid base URL format: ${projectConfig.baseURL}`);
+      console.error(`[MCP Interceptor] Using default: http://localhost:3000`);
+      projectConfig.baseURL = 'http://localhost:3000';
+    }
   } catch (err) {
     console.error(`[MCP Interceptor] Error loading config: ${err.message}`);
   }

--- a/src/generators/project-config.ts
+++ b/src/generators/project-config.ts
@@ -14,10 +14,32 @@ export async function generateProjectConfig(projectPath: string): Promise<void> 
   });
   
   const baseURL = await new Promise<string>((resolve) => {
-    rl.question(chalk.blue('🌐 Enter your application base URL (default: http://localhost:3000): '), (url) => {
-      rl.close();
-      resolve(url.trim() || 'http://localhost:3000');
-    });
+    const askForUrl = () => {
+      rl.question(chalk.blue('🌐 Enter your application base URL (default: http://localhost:3000): '), (url) => {
+        const inputUrl = url.trim() || 'http://localhost:3000';
+        
+        // Validate URL format
+        if (!inputUrl.startsWith('http://') && !inputUrl.startsWith('https://')) {
+          console.log(chalk.red('❌ URL must start with http:// or https://'));
+          console.log(chalk.yellow('   Example: http://localhost:3000 or https://example.com'));
+          askForUrl(); // Ask again
+          return;
+        }
+        
+        try {
+          // Try to parse URL to ensure it's valid
+          new URL(inputUrl);
+          rl.close();
+          resolve(inputUrl);
+        } catch (error) {
+          console.log(chalk.red('❌ Invalid URL format'));
+          console.log(chalk.yellow('   Example: http://localhost:3000 or https://example.com'));
+          askForUrl(); // Ask again
+        }
+      });
+    };
+    
+    askForUrl();
   });
 
   const configSource = path.join(__dirname, '../../templates/claude-playwright.config.js');


### PR DESCRIPTION
## Summary
Adds comprehensive URL validation to prevent MCP server connection failures due to malformed base URLs.

## Changes
- ✅ Project config generator validates URLs must start with `http://` or `https://`
- ✅ Interactive re-prompting if user enters invalid URL
- ✅ Interceptor auto-fixes missing protocol by adding `http://`
- ✅ Interceptor validates URL format and falls back to default if invalid
- ✅ Clear error messages guide users to correct format

## Problem Solved
Previously, users could enter URLs like `localhost:3002` without protocol, causing:
- MCP server connection failures
- URL parsing errors in interceptor
- Confusing error messages

## Testing
1. Run `claude-playwright configure-mcp`
2. Try entering invalid URLs:
   - `localhost:3002` → Will prompt for correction
   - `3002` → Will prompt for correction
   - `http://localhost:3002` → Accepted ✅

## Impact
- Prevents configuration errors at setup time
- Self-healing interceptor fixes existing invalid configs
- Better user experience with clear validation messages